### PR TITLE
General improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ $router->add(['GET', 'POST'], '/resource/path', function (ServerRequestInterface
 
 ### Resource Pattern Matching
 
-You can define patterns to create routes that automatically extract variables from the route path, e.g. getting a product's ID or the slug for a blog entry.
+You can define patterns to create routes that automatically extract variables from the route path, e.g. getting a product's ID or the slug for a blog entry. Variables are defined by an opening curly bracket (`{`), any alpha-numeric characters or underscore (`A-Z`, `a-z`, `0-9`, `_`), and a closing curly bracket (`}`).
 
 ```php
 <?php
@@ -114,6 +114,8 @@ $router->add(
     }
 );
 ```
+
+#### Resource Pattern Constraints
 
 Routes that contain patterns can optionally specify the constraints to fulfill those patterns. Constraints are specified by passing in an additional array. For example, maybe you want to ensure a product ID only contains digits.
 
@@ -144,7 +146,30 @@ $router->add(
 
 The above example essentially combines the path and the constraints to create a regex pattern of `/products/(\d+)`. It will match on requests for `/products/123`, but will not match on `/products/ABC123`.
 
-#### Optional Route Patterns
+Optionally, you can specify the constraints directly in the pattern. This has the exact same effect as the previous example, but might be more difficult to read for complex routes. After the variable name, type a regex value surrounded by angle brackets (`<`, `>`).
+```php
+<?php
+
+use Bitty\Http\Response;
+use Bitty\Router\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+$router = new Router(...);
+
+$router->add(
+    'GET',
+
+    // Define the variables and constraints.
+    '/products/{id<\d+>}',
+
+    // Our callback can access the variable from the Request object.
+    function (ServerRequestInterface $request) {
+        return new Response('You requested product '.$request->getAttribute('id'));
+    },
+);
+```
+
+#### Optional Resource Patterns
 
 Sometimes parameters aren't necessary to fulfill the request and can default to a set value. You can specify a parameter as optional by adding a `?` after the variable name. Additionally, you can enter a value after the `?` to use as the default. If no value is given, it uses to `null`.
 
@@ -161,7 +186,7 @@ $router->add(
     'GET',
 
     // Match against multiple optional parameters.
-    '/blog/{year?2019}/{month?}/{day?}',
+    '/blog/{year<\d{4}>?2019}/{month?}/{day?}',
 
     // Our callback.
     function (ServerRequestInterface $request) {
@@ -174,7 +199,6 @@ $router->add(
 
     // Constraints.
     [
-        'year' => '\d+',
         'month' => '\d+',
         'day' => '\d+',
     ]

--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ use Psr\Http\Message\ServerRequestInterface;
 $router = new Router(...);
 
 $router->add(['GET', 'POST'], '/resource/path', function (ServerRequestInterface $request) {
-    if ($request->getMethod() === 'GET') {
-        return new Response('You did a GET');
+    if ($request->getMethod() === 'POST') {
+        return new Response('You did a POST');
     }
 
-    return new Response('You did a POST');
+    return new Response('You did a GET');
 });
 ```
 
@@ -275,7 +275,11 @@ use Bitty\Router\Router;
 
 $router = new Router(...);
 
+// Set it directly.
 $router->add('GET', '/foo', ExampleController::class, [], 'foo_route');
+
+// Set it after.
+$router->add('GET', '/foo', ExampleController::class)->setName('foo_route');
 ```
 
 ## Checking For a Route
@@ -318,7 +322,7 @@ $route->setMethods(['GET', 'POST']);
 
 ### By Request
 
-You can use the `find()` method to fetch a route based on a request. This allows you to find both named or unnamed routes. Similar to `get()`, if the route doesn't exist a `Bitty\Router\Exception\NotFoundException` will be thrown. If it finds a route, the route object will be returned.
+You can use the `match()` method to fetch a route based on a request. This allows you to find both named or unnamed routes. Similar to `get()`, if the route doesn't exist a `Bitty\Router\Exception\NotFoundException` will be thrown. If it finds a route, the route object will be returned.
 
 ```php
 <?php
@@ -332,7 +336,7 @@ $router = new Router(...);
 $request = ...;
 
 // Find a matching route
-$route = $router->find($request);
+$route = $router->match($request);
 ```
 
 ## Generating a URI

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ $router->add(
     // Our callback can access the variable from the Request object.
     function (ServerRequestInterface $request) {
         return new Response('You requested product '.$request->getAttribute('id'));
-    },
+    }
 );
 ```
 

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -16,5 +16,5 @@
         "@default": true
     },
     "testFramework": "phpunit",
-    "bootstrap": "./tests/bootstrap.php"
+    "bootstrap": "vendor/autoload.php"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.5/phpunit.xsd"
-    bootstrap="tests/bootstrap.php"
+    bootstrap="vendor/autoload.php"
     backupGlobals="false"
     backupStaticAttributes="false"
     beStrictAboutTestsThatDoNotTestAnything="true"
@@ -39,4 +39,9 @@
             <directory>src/</directory>
         </whitelist>
     </filter>
+
+    <php>
+        <ini name="memory_limit" value="-1" />
+        <ini name="error_reporting" value="-1" />
+    </php>
 </phpunit>

--- a/src/Route.php
+++ b/src/Route.php
@@ -77,13 +77,13 @@ class Route implements RouteInterface
     }
 
     /**
-     * Sets the route methods.
-     *
-     * @param string[]|string $methods List of request methods to allow.
+     * {@inheritDoc}
      */
-    public function setMethods($methods): void
+    public function setMethods($methods): RouteInterface
     {
         $this->methods = array_map('strtoupper', (array) $methods);
+
+        return $this;
     }
 
     /**
@@ -95,14 +95,14 @@ class Route implements RouteInterface
     }
 
     /**
-     * Sets the route path.
-     *
-     * @param string $path Route path.
+     * {@inheritDoc}
      */
-    public function setPath(string $path): void
+    public function setPath(string $path): RouteInterface
     {
-        $this->path = $path;
+        $this->path = '/'.ltrim($path, '/');
         $this->pattern = null;
+
+        return $this;
     }
 
     /**
@@ -114,18 +114,14 @@ class Route implements RouteInterface
     }
 
     /**
-     * Sets the route callback.
-     *
-     * @param callable|string $callback Callback to call.
-     *
-     * @throws \InvalidArgumentException
+     * {@inheritDoc}
      */
-    public function setCallback($callback): void
+    public function setCallback($callback): RouteInterface
     {
         if (is_callable($callback) || is_string($callback)) {
             $this->callback = $callback;
 
-            return;
+            return $this;
         }
 
         throw new \InvalidArgumentException(
@@ -145,14 +141,14 @@ class Route implements RouteInterface
     }
 
     /**
-     * Sets the route constraints.
-     *
-     * @param string[] $constraints List of constraints for route variables.
+     * {@inheritDoc}
      */
-    public function setConstraints(array $constraints): void
+    public function setConstraints(array $constraints): RouteInterface
     {
         $this->constraints = $constraints;
         $this->pattern = null;
+
+        return $this;
     }
 
     /**
@@ -161,6 +157,17 @@ class Route implements RouteInterface
     public function getConstraints(): array
     {
         return $this->constraints;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addConstraints(array $constraints): RouteInterface
+    {
+        $this->constraints = array_merge($this->constraints, $constraints);
+        $this->pattern = null;
+
+        return $this;
     }
 
     /**
@@ -217,13 +224,13 @@ class Route implements RouteInterface
     }
 
     /**
-     * Sets the route name.
-     *
-     * @param string|null $name Route name.
+     * {@inheritDoc}
      */
-    public function setName($name): void
+    public function setName(?string $name): RouteInterface
     {
         $this->name = $name;
+
+        return $this;
     }
 
     /**
@@ -235,13 +242,13 @@ class Route implements RouteInterface
     }
 
     /**
-     * Sets the route parameters.
-     *
-     * @param array<string|null> $params Parameters to pass to the route.
+     * {@inheritDoc}
      */
-    public function setParams(array $params): void
+    public function setParams(array $params): RouteInterface
     {
         $this->params = $params;
+
+        return $this;
     }
 
     /**
@@ -250,5 +257,15 @@ class Route implements RouteInterface
     public function getParams(): array
     {
         return $this->params;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addParams(array $params): RouteInterface
+    {
+        $this->params = array_merge($this->params, $params);
+
+        return $this;
     }
 }

--- a/src/Route.php
+++ b/src/Route.php
@@ -7,13 +7,6 @@ use Bitty\Router\RouteInterface;
 class Route implements RouteInterface
 {
     /**
-     * Route identifier.
-     *
-     * @var string
-     */
-    private $identifier = null;
-
-    /**
      * List of allowed request methods, e.g. GET, POST, etc.
      *
      * @var string[]
@@ -68,30 +61,19 @@ class Route implements RouteInterface
      * @param callable|string $callback
      * @param string[] $constraints
      * @param string|null $name
-     * @param int $identifier
      */
     public function __construct(
         $methods,
         string $path,
         $callback,
         array $constraints = [],
-        ?string $name = null,
-        int $identifier = 0
+        ?string $name = null
     ) {
         $this->setMethods($methods);
         $this->setPath($path);
         $this->setCallback($callback);
         $this->setConstraints($constraints);
         $this->setName($name);
-        $this->identifier = 'route_'.$identifier;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getIdentifier(): string
-    {
-        return $this->identifier;
     }
 
     /**

--- a/src/Route.php
+++ b/src/Route.php
@@ -36,13 +36,6 @@ class Route implements RouteInterface
     private $constraints = [];
 
     /**
-     * The URI pattern to match.
-     *
-     * @var string|null
-     */
-    private $pattern = null;
-
-    /**
      * Route name.
      *
      * @var string|null
@@ -55,6 +48,13 @@ class Route implements RouteInterface
      * @var array<string|null>
      */
     private $params = [];
+
+    /**
+     * The compiled route data.
+     *
+     * @var array|null
+     */
+    private $compiled = null;
 
     /**
      * @param string[]|string $methods
@@ -101,7 +101,7 @@ class Route implements RouteInterface
     public function setPath(string $path): RouteInterface
     {
         $this->path = '/'.ltrim($path, '/');
-        $this->pattern = null;
+        $this->compiled = null;
 
         return $this;
     }
@@ -147,7 +147,7 @@ class Route implements RouteInterface
     public function setConstraints(array $constraints): RouteInterface
     {
         $this->constraints = $constraints;
-        $this->pattern = null;
+        $this->compiled = null;
 
         return $this;
     }
@@ -166,24 +166,9 @@ class Route implements RouteInterface
     public function addConstraints(array $constraints): RouteInterface
     {
         $this->constraints = array_merge($this->constraints, $constraints);
-        $this->pattern = null;
+        $this->compiled = null;
 
         return $this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getPattern(): string
-    {
-        if ($this->pattern === null) {
-            $compiled = RouteCompiler::compile($this->path, $this->constraints, $this->params);
-            $this->pattern = $compiled['regex'];
-            $this->params = $compiled['params'];
-            $this->constraints = $compiled['constraints'];
-        }
-
-        return $this->pattern;
     }
 
     /**
@@ -230,5 +215,23 @@ class Route implements RouteInterface
         $this->params = array_merge($this->params, $params);
 
         return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function compile(): array
+    {
+        if ($this->compiled === null) {
+            $compiled = RouteCompiler::compile($this->path, $this->constraints, $this->params);
+            $this->compiled = [
+                'regex' => $compiled['regex'],
+                'tokens' => $compiled['tokens'],
+            ];
+            $this->params = $compiled['params'];
+            $this->constraints = $compiled['constraints'];
+        }
+
+        return $this->compiled;
     }
 }

--- a/src/Route.php
+++ b/src/Route.php
@@ -186,7 +186,7 @@ class Route implements RouteInterface
         $pos = 0;
         $matches = [];
         preg_match_all(
-            $deliminator.'\{(\w+)(\?[^\}]*?)?\}'.$deliminator,
+            $deliminator.'\{(\w+)(<.*?>)?(\?[^\}]*?)?\}'.$deliminator,
             $this->path,
             $matches,
             PREG_SET_ORDER|PREG_OFFSET_CAPTURE
@@ -197,13 +197,18 @@ class Route implements RouteInterface
             /** @var int $offset */
             $offset = $match[0][1];
             $name = $match[1][0];
+
+            if (isset($match[2]) && !empty($match[2][0])) {
+                $this->constraints[$name] = substr($match[2][0], 1, -1);
+            }
+
             $regex = '(?<'.$name.'>'.($this->constraints[$name] ?? '.+?').')';
             $previousText = substr($this->path, $pos, $offset - $pos);
             $previousChar = substr($previousText, -1);
             $pos = $offset + strlen($string);
 
-            if (isset($match[2])) {
-                $default = substr($match[2][0], 1);
+            if (isset($match[3])) {
+                $default = substr($match[3][0], 1);
                 $this->params[$name] = $default ?: null;
                 if (preg_match($deliminator.'['.$separators.']'.$deliminator, $previousChar)) {
                     $previousText = substr($previousText, 0, -1);

--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -46,6 +46,16 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * {@inheritDoc}
      */
+    public function addCollection(RouteCollectionInterface $collection): void
+    {
+        foreach ($collection->all() as $route) {
+            $this->add($route);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function has(string $name): bool
     {
         return isset($this->routes[$name]);
@@ -73,5 +83,65 @@ class RouteCollection implements RouteCollectionInterface
         }
 
         unset($this->routes[$name]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setMethods($methods): void
+    {
+        foreach ($this->routes as $route) {
+            $route->setMethods($methods);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addPrefix(string $prefix): void
+    {
+        foreach ($this->routes as $route) {
+            $route->setPath($prefix.$route->getPath());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addNamePrefix(string $prefix): void
+    {
+        $routes = [];
+
+        foreach ($this->routes as $name => $route) {
+            $routes[$prefix.$name] = $route;
+            $name = $route->getName();
+            if ($name === null) {
+                continue;
+            }
+
+            $route->setName($prefix.$name);
+        }
+
+        $this->routes = $routes;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addConstraints(array $constraints): void
+    {
+        foreach ($this->routes as $route) {
+            $route->addConstraints($constraints);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addParams(array $params): void
+    {
+        foreach ($this->routes as $route) {
+            $route->addParams($params);
+        }
     }
 }

--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -3,7 +3,6 @@
 namespace Bitty\Router;
 
 use Bitty\Router\Exception\NotFoundException;
-use Bitty\Router\Route;
 use Bitty\Router\RouteCollectionInterface;
 use Bitty\Router\RouteInterface;
 
@@ -32,29 +31,16 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * {@inheritDoc}
      */
-    public function add(
-        $methods,
-        string $path,
-        $callback,
-        array $constraints = [],
-        ?string $name = null
-    ): RouteInterface {
-        $route = new Route(
-            $methods,
-            $path,
-            $callback,
-            $constraints,
-            $name,
-            $this->routeCounter++
-        );
+    public function add(RouteInterface $route): void
+    {
+        $name = $route->getName();
 
-        if ($name === null) {
-            $name = $route->getIdentifier();
+        if (empty($name)) {
+            $name = '_route_'.$this->routeCounter;
         }
 
         $this->routes[$name] = $route;
-
-        return $route;
+        $this->routeCounter++;
     }
 
     /**

--- a/src/RouteCollectionInterface.php
+++ b/src/RouteCollectionInterface.php
@@ -22,6 +22,13 @@ interface RouteCollectionInterface
     public function add(RouteInterface $route): void;
 
     /**
+     * Adds a collection to the collection.
+     *
+     * @param RouteCollectionInterface $collection
+     */
+    public function addCollection(RouteCollectionInterface $collection): void;
+
+    /**
      * Checks if a route exists.
      *
      * @param string $name
@@ -47,4 +54,39 @@ interface RouteCollectionInterface
      * @param string $name
      */
     public function remove(string $name): void;
+
+    /**
+     * Sets the route methods for the entire collection.
+     *
+     * @param string[]|string $methods List of request methods to allow.
+     */
+    public function setMethods($methods): void;
+
+    /**
+     * Adds a route prefix to the entire collection.
+     *
+     * @param string $prefix
+     */
+    public function addPrefix(string $prefix): void;
+
+    /**
+     * Adds a route name prefix to the entire collection.
+     *
+     * @param string $prefix
+     */
+    public function addNamePrefix(string $prefix): void;
+
+    /**
+     * Adds route constraints to the entire collection.
+     *
+     * @param string[] $constraints List of constraints for route variables.
+     */
+    public function addConstraints(array $constraints): void;
+
+    /**
+     * Adds route parameters to the entire collection.
+     *
+     * @param array<string|null> $params Parameters to pass to the route.
+     */
+    public function addParams(array $params): void;
 }

--- a/src/RouteCollectionInterface.php
+++ b/src/RouteCollectionInterface.php
@@ -17,21 +17,9 @@ interface RouteCollectionInterface
     /**
      * Adds a new route.
      *
-     * @param string[]|string $methods
-     * @param string $path
-     * @param callable|string|mixed $callback
-     * @param string[] $constraints
-     * @param string|null $name
-     *
-     * @return RouteInterface
+     * @param RouteInterface $route
      */
-    public function add(
-        $methods,
-        string $path,
-        $callback,
-        array $constraints = [],
-        ?string $name = null
-    ): RouteInterface;
+    public function add(RouteInterface $route): void;
 
     /**
      * Checks if a route exists.

--- a/src/RouteCompiler.php
+++ b/src/RouteCompiler.php
@@ -32,13 +32,13 @@ class RouteCompiler
         $pos = 0;
         $matches = [];
         preg_match_all(
-            self::DELIMINATOR.'\{(\w+)(<.*?>)?(\?[^\}]*?)?\}'.self::DELIMINATOR,
+            '`\{(\w+)(<.*?>)?(\?[^\}]*?)?\}`',
             $path,
             $matches,
             PREG_SET_ORDER|PREG_OFFSET_CAPTURE
         );
 
-        $compiled = '';
+        $regex = '';
         foreach ($matches as $match) {
             $string = $match[0][0];
             /** @var int $offset */
@@ -47,14 +47,14 @@ class RouteCompiler
             $previousText = substr($path, $pos, $offset - $pos);
             $pos = $offset + strlen($string);
 
-            $compiled .= self::processMatch($match, $constraints, $params, $name, $previousText);
+            $regex .= self::processMatch($match, $constraints, $params, $name, $previousText);
         }
 
         $remainingText = substr($path, $pos);
-        $compiled .= preg_quote($remainingText, self::DELIMINATOR);
+        $regex .= preg_quote($remainingText, self::DELIMINATOR);
 
         return [
-            'regex' => self::DELIMINATOR.'^'.$compiled.'$'.self::DELIMINATOR,
+            'regex' => self::DELIMINATOR.'^'.$regex.'$'.self::DELIMINATOR,
             'constraints' => $constraints,
             'params' => $params,
         ];

--- a/src/RouteCompiler.php
+++ b/src/RouteCompiler.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Bitty\Router;
+
+class RouteCompiler
+{
+    /**
+     * Regex deliminator.
+     *
+     * @var string
+     */
+    public const DELIMINATOR = '`';
+
+    /**
+     * Separators that are seen as optional.
+     *
+     * @var string
+     */
+    public const SEPARATORS = '/.';
+
+    /**
+     * Compiles a regex for the given path.
+     *
+     * @param string $path
+     * @param string[] $constraints
+     * @param mixed[] $params
+     *
+     * @return array
+     */
+    public static function compile(string $path, array $constraints = [], array $params = []): array
+    {
+        $pos = 0;
+        $matches = [];
+        preg_match_all(
+            self::DELIMINATOR.'\{(\w+)(<.*?>)?(\?[^\}]*?)?\}'.self::DELIMINATOR,
+            $path,
+            $matches,
+            PREG_SET_ORDER|PREG_OFFSET_CAPTURE
+        );
+
+        $compiled = '';
+        foreach ($matches as $match) {
+            $string = $match[0][0];
+            /** @var int $offset */
+            $offset = $match[0][1];
+            $name = $match[1][0];
+            $previousText = substr($path, $pos, $offset - $pos);
+            $pos = $offset + strlen($string);
+
+            $compiled .= self::processMatch($match, $constraints, $params, $name, $previousText);
+        }
+
+        $remainingText = substr($path, $pos);
+        $compiled .= preg_quote($remainingText, self::DELIMINATOR);
+
+        return [
+            'regex' => self::DELIMINATOR.'^'.$compiled.'$'.self::DELIMINATOR,
+            'constraints' => $constraints,
+            'params' => $params,
+        ];
+    }
+
+    /**
+     * Processes a path match.
+     *
+     * @param array $match
+     * @param array $constraints
+     * @param array $params
+     * @param string $name
+     * @param string $previousText
+     *
+     * @return string
+     */
+    private static function processMatch(
+        array $match,
+        array &$constraints,
+        array &$params,
+        string $name,
+        string $previousText
+    ): string {
+        if (!empty($match[2][0])) {
+            $constraints[$name] = substr($match[2][0], 1, -1);
+        }
+
+        $regex = '(?<'.$name.'>'.($constraints[$name] ?? '.+?').')';
+
+        if (isset($match[3])) {
+            $default = substr($match[3][0], 1);
+            $params[$name] = $default ?: null;
+
+            $previousChar = substr($previousText, -1);
+            if (preg_match('`['.self::SEPARATORS.']`', $previousChar)) {
+                $previousText = substr($previousText, 0, -1);
+                $regex = '(?:'.preg_quote($previousChar, self::DELIMINATOR).$regex.')?';
+            } else {
+                $regex .= '?';
+            }
+        }
+
+        return preg_quote($previousText, self::DELIMINATOR).$regex;
+    }
+}

--- a/src/RouteHandler.php
+++ b/src/RouteHandler.php
@@ -46,9 +46,7 @@ class RouteHandler implements RequestHandlerInterface
         }
 
         if ($action !== null) {
-            /**
-             * @var callable
-             */
+            /** @var callable $callable */
             $callable = [$controller, $action];
 
             return call_user_func_array($callable, [$request]);

--- a/src/RouteHandler.php
+++ b/src/RouteHandler.php
@@ -35,7 +35,7 @@ class RouteHandler implements RequestHandlerInterface
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $route    = $this->router->find($request);
+        $route    = $this->router->match($request);
         $callback = $route->getCallback();
         $params   = $route->getParams();
 

--- a/src/RouteInterface.php
+++ b/src/RouteInterface.php
@@ -88,13 +88,6 @@ interface RouteInterface
     public function addConstraints(array $constraints): RouteInterface;
 
     /**
-     * Gets a matchable pattern that combines that path and constraints.
-     *
-     * @return string
-     */
-    public function getPattern(): string;
-
-    /**
      * Sets the route name.
      *
      * @param string|null $name Route name.
@@ -134,4 +127,13 @@ interface RouteInterface
      * @return RouteInterface
      */
     public function addParams(array $params): RouteInterface;
+
+    /**
+     * Gets an array of compiled route data.
+     *
+     * @return array
+     *
+     * @internal
+     */
+    public function compile(): array;
 }

--- a/src/RouteInterface.php
+++ b/src/RouteInterface.php
@@ -5,13 +5,6 @@ namespace Bitty\Router;
 interface RouteInterface
 {
     /**
-     * Gets the route identifier.
-     *
-     * @return string
-     */
-    public function getIdentifier(): string;
-
-    /**
      * Gets the route methods.
      *
      * @return string[]

--- a/src/RouteInterface.php
+++ b/src/RouteInterface.php
@@ -5,11 +5,29 @@ namespace Bitty\Router;
 interface RouteInterface
 {
     /**
+     * Sets the route methods.
+     *
+     * @param string[]|string $methods List of request methods to allow.
+     *
+     * @return RouteInterface
+     */
+    public function setMethods($methods): RouteInterface;
+
+    /**
      * Gets the route methods.
      *
      * @return string[]
      */
     public function getMethods(): array;
+
+    /**
+     * Sets the route path.
+     *
+     * @param string $path Route path.
+     *
+     * @return RouteInterface
+     */
+    public function setPath(string $path): RouteInterface;
 
     /**
      * Gets the route path.
@@ -19,11 +37,31 @@ interface RouteInterface
     public function getPath(): string;
 
     /**
+     * Sets the route callback.
+     *
+     * @param callable|string $callback Callback to call.
+     *
+     * @return RouteInterface
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function setCallback($callback): RouteInterface;
+
+    /**
      * Gets the route callback.
      *
      * @return callable|string
      */
     public function getCallback();
+
+    /**
+     * Sets the route constraints.
+     *
+     * @param string[] $constraints List of constraints for route variables.
+     *
+     * @return RouteInterface
+     */
+    public function setConstraints(array $constraints): RouteInterface;
 
     /**
      * Gets the route constraints.
@@ -41,11 +79,29 @@ interface RouteInterface
     public function getConstraints(): array;
 
     /**
+     * Adds to the route constraints.
+     *
+     * @param string[] $constraints List of constraints for route variables.
+     *
+     * @return RouteInterface
+     */
+    public function addConstraints(array $constraints): RouteInterface;
+
+    /**
      * Gets a matchable pattern that combines that path and constraints.
      *
      * @return string
      */
     public function getPattern(): string;
+
+    /**
+     * Sets the route name.
+     *
+     * @param string|null $name Route name.
+     *
+     * @return RouteInterface
+     */
+    public function setName(?string $name): RouteInterface;
 
     /**
      * Gets the route name.
@@ -55,9 +111,27 @@ interface RouteInterface
     public function getName(): ?string;
 
     /**
+     * Sets the route parameters.
+     *
+     * @param array<string|null> $params Parameters to pass to the route.
+     *
+     * @return RouteInterface
+     */
+    public function setParams(array $params): RouteInterface;
+
+    /**
      * Gets the route parameters.
      *
      * @return array<string|null>
      */
     public function getParams(): array;
+
+    /**
+     * Adds to the route parameters.
+     *
+     * @param array<string|null> $params Parameters to pass to the route.
+     *
+     * @return RouteInterface
+     */
+    public function addParams(array $params): RouteInterface;
 }

--- a/src/RouteMatcher.php
+++ b/src/RouteMatcher.php
@@ -77,9 +77,9 @@ class RouteMatcher implements RouteMatcherInterface
      */
     private function isPathMatch(RouteInterface $route, string $path): bool
     {
-        $pattern = $route->getPattern();
+        $compiled = $route->compile();
         $matches = [];
-        if (!preg_match($pattern, $path, $matches)) {
+        if (!preg_match($compiled['regex'], $path, $matches)) {
             return false;
         }
 

--- a/src/RouteMatcher.php
+++ b/src/RouteMatcher.php
@@ -79,7 +79,7 @@ class RouteMatcher implements RouteMatcherInterface
             return false;
         }
 
-        $params = $route->getParams();
+        $params = [];
         foreach ($matches as $key => $value) {
             if (is_int($key) || empty($value)) {
                 continue;
@@ -88,9 +88,7 @@ class RouteMatcher implements RouteMatcherInterface
             $params[$key] = $value;
         }
 
-        if (method_exists($route, 'setParams')) {
-            $route->setParams($params);
-        }
+        $route->addParams($params);
 
         return true;
     }

--- a/src/RouteMatcher.php
+++ b/src/RouteMatcher.php
@@ -28,7 +28,7 @@ class RouteMatcher implements RouteMatcherInterface
      */
     public function match(ServerRequestInterface $request): RouteInterface
     {
-        $method = $request->getMethod();
+        $method = strtoupper($request->getMethod());
         $path   = '/'.ltrim($request->getUri()->getPath(), '/');
 
         foreach ($this->routes->all() as $route) {
@@ -58,6 +58,10 @@ class RouteMatcher implements RouteMatcherInterface
         if ($methods === []) {
             // any method allowed
             return true;
+        }
+
+        if ($method === 'HEAD') {
+            $method = 'GET';
         }
 
         return in_array($method, $methods, true);

--- a/src/Router.php
+++ b/src/Router.php
@@ -2,7 +2,9 @@
 
 namespace Bitty\Router;
 
+use Bitty\Router\Route;
 use Bitty\Router\RouteCollectionInterface;
+use Bitty\Router\RouteInterface;
 use Bitty\Router\RouteMatcherInterface;
 use Bitty\Router\RouterInterface;
 use Bitty\Router\UriGeneratorInterface;
@@ -50,7 +52,17 @@ class Router implements RouterInterface
         array $constraints = [],
         ?string $name = null
     ): RouteInterface {
-        return $this->routes->add($methods, $path, $callback, $constraints, $name);
+        $route = new Route(
+            $methods,
+            $path,
+            $callback,
+            $constraints,
+            $name
+        );
+
+        $this->routes->add($route);
+
+        return $route;
     }
 
     /**

--- a/src/Router.php
+++ b/src/Router.php
@@ -84,7 +84,7 @@ class Router implements RouterInterface
     /**
      * {@inheritDoc}
      */
-    public function find(ServerRequestInterface $request): RouteInterface
+    public function match(ServerRequestInterface $request): RouteInterface
     {
         return $this->matcher->match($request);
     }

--- a/src/RouterInterface.php
+++ b/src/RouterInterface.php
@@ -48,15 +48,15 @@ interface RouterInterface
     public function get(string $name): RouteInterface;
 
     /**
-     * Finds a route for the given request.
+     * Matches a route for the given request.
      *
      * @param ServerRequestInterface $request
      *
      * @return RouteInterface
      *
-     * @throws NotFoundException When unable to find a route.
+     * @throws NotFoundException When unable to match a route.
      */
-    public function find(ServerRequestInterface $request): RouteInterface;
+    public function match(ServerRequestInterface $request): RouteInterface;
 
     /**
      * Generates a URI for a named route.

--- a/src/UriGenerator.php
+++ b/src/UriGenerator.php
@@ -43,6 +43,9 @@ class UriGenerator implements UriGeneratorInterface
 
         if ($type === self::ABSOLUTE_URI) {
             $uri = new Uri($this->domain.'/'.ltrim($path, '/'));
+        } elseif ($type === self::NETWORK_URI) {
+            $uri = new Uri($this->domain.'/'.ltrim($path, '/'));
+            $uri = $uri->withScheme('');
         } else {
             $uri = new Uri($path);
         }
@@ -53,7 +56,7 @@ class UriGenerator implements UriGeneratorInterface
                 .'='.urlencode(urldecode($value));
         }
 
-        return $uri->withQuery(implode('&', $query));
+        return strval($uri->withQuery(implode('&', $query)));
     }
 
     /**

--- a/src/UriGeneratorInterface.php
+++ b/src/UriGeneratorInterface.php
@@ -25,7 +25,7 @@ interface UriGeneratorInterface
     public const ABSOLUTE_PATH = 'absolute-path';
 
     /**
-     * Indicates to return an network URI (no scheme prefix).
+     * Indicates to return a network URI (no scheme prefix).
      *
      * For example, //www.example.com/some/path.html
      *

--- a/src/UriGeneratorInterface.php
+++ b/src/UriGeneratorInterface.php
@@ -25,6 +25,15 @@ interface UriGeneratorInterface
     public const ABSOLUTE_PATH = 'absolute-path';
 
     /**
+     * Indicates to return an network URI (no scheme prefix).
+     *
+     * For example, //www.example.com/some/path.html
+     *
+     * @var string
+     */
+    public const NETWORK_URI = 'network-uri';
+
+    /**
      * Generates a URI for the given named route.
      *
      * @param string $name

--- a/tests/RouteCollectionTest.php
+++ b/tests/RouteCollectionTest.php
@@ -65,6 +65,24 @@ class RouteCollectionTest extends TestCase
         self::assertSame($routeB, $actualB);
     }
 
+    public function testAddCollection(): void
+    {
+        $nameA  = uniqid('name');
+        $nameB  = uniqid('name');
+        $routeA = $this->createConfiguredMock(RouteInterface::class, ['getName' => $nameA]);
+        $routeB = $this->createConfiguredMock(RouteInterface::class, ['getName' => $nameB]);
+
+        $collection = new RouteCollection();
+        $collection->add($routeA);
+        $collection->add($routeB);
+
+        $this->fixture->addCollection($collection);
+
+        $actual = $this->fixture->all();
+
+        self::assertEquals([$nameA => $routeA, $nameB => $routeB], $actual);
+    }
+
     public function testAll(): void
     {
         $nameA  = uniqid('name');
@@ -131,5 +149,120 @@ class RouteCollectionTest extends TestCase
         $actual = $this->fixture->has($name);
 
         self::assertFalse($actual);
+    }
+
+    public function testSetMethods(): void
+    {
+        $methods = [uniqid()];
+        $routeA  = $this->createMock(RouteInterface::class);
+        $routeB  = $this->createMock(RouteInterface::class);
+
+        $this->fixture->add($routeA);
+        $this->fixture->add($routeB);
+
+        $routeA->expects(self::once())
+            ->method('setMethods')
+            ->with($methods);
+
+        $routeB->expects(self::once())
+            ->method('setMethods')
+            ->with($methods);
+
+        $this->fixture->setMethods($methods);
+    }
+
+    public function testAddPrefix(): void
+    {
+        $prefix = uniqid();
+        $pathA  = uniqid();
+        $pathB  = uniqid();
+        $routeA = $this->createConfiguredMock(RouteInterface::class, ['getPath' => $pathA]);
+        $routeB = $this->createConfiguredMock(RouteInterface::class, ['getPath' => $pathB]);
+
+        $this->fixture->add($routeA);
+        $this->fixture->add($routeB);
+
+        $routeA->expects(self::once())
+            ->method('setPath')
+            ->with($prefix.$pathA);
+
+        $routeB->expects(self::once())
+            ->method('setPath')
+            ->with($prefix.$pathB);
+
+        $this->fixture->addPrefix($prefix);
+    }
+
+    public function testAddNamePrefix(): void
+    {
+        $prefix = uniqid();
+        $nameA  = uniqid();
+        $nameB  = uniqid();
+        $routeA = $this->createConfiguredMock(RouteInterface::class, ['getName' => $nameA]);
+        $routeB = $this->createConfiguredMock(RouteInterface::class, ['getName' => null]);
+        $routeC = $this->createConfiguredMock(RouteInterface::class, ['getName' => $nameB]);
+
+        $this->fixture->add($routeA);
+        $this->fixture->add($routeB);
+        $this->fixture->add($routeC);
+
+        $routeA->expects(self::once())
+            ->method('setName')
+            ->with($prefix.$nameA);
+
+        $routeC->expects(self::once())
+            ->method('setName')
+            ->with($prefix.$nameB);
+
+        $this->fixture->addNamePrefix($prefix);
+
+        $actual = $this->fixture->all();
+
+        $expected = [
+            $prefix.$nameA => $routeA,
+            $prefix.'_route_1' => $routeB,
+            $prefix.$nameB => $routeC,
+        ];
+        self::assertEquals($expected, $actual);
+    }
+
+    public function testAddConstraints(): void
+    {
+        $constraints = [uniqid()];
+        $routeA      = $this->createMock(RouteInterface::class);
+        $routeB      = $this->createMock(RouteInterface::class);
+
+        $this->fixture->add($routeA);
+        $this->fixture->add($routeB);
+
+        $routeA->expects(self::once())
+            ->method('addConstraints')
+            ->with($constraints);
+
+        $routeB->expects(self::once())
+            ->method('addConstraints')
+            ->with($constraints);
+
+        $this->fixture->addConstraints($constraints);
+    }
+
+    public function testAddParams(): void
+    {
+        $params = [uniqid()];
+        $routeA = $this->createMock(RouteInterface::class);
+        $routeB = $this->createMock(RouteInterface::class);
+
+        $this->fixture->add($routeA);
+        $this->fixture->add($routeB);
+
+        $routeA->expects(self::once())
+            ->method('addParams')
+            ->with($params);
+
+        $routeB->expects(self::once())
+            ->method('addParams')
+            ->with($params);
+
+        $this->fixture->addParams($params);
     }
 }

--- a/tests/RouteCollectionTest.php
+++ b/tests/RouteCollectionTest.php
@@ -27,91 +27,65 @@ class RouteCollectionTest extends TestCase
         self::assertInstanceOf(RouteCollectionInterface::class, $this->fixture);
     }
 
-    public function testAdd(): void
+    public function testAddWithName(): void
     {
-        $methods     = ['get', 'pOsT'];
-        $path        = uniqid();
-        $constraints = [uniqid()];
-        $name        = uniqid();
-        $callback    = function () {
-        };
+        $name  = uniqid('name');
+        $route = $this->createConfiguredMock(RouteInterface::class, ['getName' => $name]);
 
-        $this->fixture->add($methods, $path, $callback, $constraints, $name);
+        $this->fixture->add($route);
 
         $actual = $this->fixture->get($name);
 
-        self::assertInstanceOf(RouteInterface::class, $actual);
-        self::assertEquals(['GET', 'POST'], $actual->getMethods());
-        self::assertEquals($path, $actual->getPath());
-        self::assertEquals($callback, $actual->getCallback());
-        self::assertEquals($constraints, $actual->getConstraints());
-        self::assertEquals($name, $actual->getName());
-        self::assertEquals('route_0', $actual->getIdentifier());
+        self::assertSame($route, $actual);
     }
 
-    public function testAddWithStringCallback(): void
+    public function testAddWithoutName(): void
     {
-        $callback = uniqid();
+        $route = $this->createMock(RouteInterface::class);
 
-        $this->fixture->add(uniqid(), uniqid(), $callback);
+        $this->fixture->add($route);
 
-        $actual = $this->fixture->get('route_0');
+        $actual = $this->fixture->get('_route_0');
 
-        self::assertEquals($callback, $actual->getCallback());
-    }
-
-    public function testAddWithoutNameUsesIdentifier(): void
-    {
-        $this->fixture->add(uniqid(), uniqid(), uniqid());
-
-        $actual = $this->fixture->get('route_0');
-
-        self::assertInstanceOf(RouteInterface::class, $actual);
-        self::assertNull($actual->getName());
-        self::assertEquals('route_0', $actual->getIdentifier());
+        self::assertSame($route, $actual);
     }
 
     public function testMultipleAddsIncrementsIdentifier(): void
     {
-        $nameA = uniqid();
-        $nameB = uniqid();
+        $routeA = $this->createMock(RouteInterface::class);
+        $routeB = $this->createMock(RouteInterface::class);
 
-        $this->fixture->add(uniqid(), uniqid(), uniqid(), [], $nameA);
-        $this->fixture->add(uniqid(), uniqid(), uniqid(), [], $nameB);
+        $this->fixture->add($routeA);
+        $this->fixture->add($routeB);
 
-        $actualA = $this->fixture->get($nameA);
-        $actualB = $this->fixture->get($nameB);
+        $actualA = $this->fixture->get('_route_0');
+        $actualB = $this->fixture->get('_route_1');
 
-        self::assertEquals('route_0', $actualA->getIdentifier());
-        self::assertEquals('route_1', $actualB->getIdentifier());
-    }
-
-    public function testAddInvalidCallbackThrowsException(): void
-    {
-        $message = 'Callback must be a callable or string; NULL given.';
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage($message);
-
-        $this->fixture->add(uniqid(), uniqid(), null);
+        self::assertSame($routeA, $actualA);
+        self::assertSame($routeB, $actualB);
     }
 
     public function testAll(): void
     {
-        $name = uniqid('name');
+        $nameA  = uniqid('name');
+        $nameB  = uniqid('name');
+        $routeA = $this->createConfiguredMock(RouteInterface::class, ['getName' => $nameA]);
+        $routeB = $this->createConfiguredMock(RouteInterface::class, ['getName' => $nameB]);
 
-        $this->fixture->add(uniqid(), uniqid(), uniqid(), [], $name);
+        $this->fixture->add($routeA);
+        $this->fixture->add($routeB);
 
         $actual = $this->fixture->all();
 
-        self::assertEquals([$name], array_keys($actual));
+        self::assertEquals([$nameA, $nameB], array_keys($actual));
     }
 
     public function testHasTrue(): void
     {
-        $name = uniqid('name');
+        $name  = uniqid('name');
+        $route = $this->createConfiguredMock(RouteInterface::class, ['getName' => $name]);
 
-        $this->fixture->add(uniqid(), uniqid(), uniqid(), [], $name);
-
+        $this->fixture->add($route);
         $actual = $this->fixture->has($name);
 
         self::assertTrue($actual);
@@ -137,9 +111,10 @@ class RouteCollectionTest extends TestCase
 
     public function testRemoveExistingRoute(): void
     {
-        $name = uniqid('name');
+        $name  = uniqid('name');
+        $route = $this->createConfiguredMock(RouteInterface::class, ['getName' => $name]);
 
-        $this->fixture->add(uniqid(), uniqid(), uniqid(), [], $name);
+        $this->fixture->add($route);
         $this->fixture->remove($name);
 
         $actual = $this->fixture->has($name);

--- a/tests/RouteHandlerTest.php
+++ b/tests/RouteHandlerTest.php
@@ -57,7 +57,7 @@ class RouteHandlerTest extends TestCase
         $this->builder->method('build')->willReturn([$callback, null]);
 
         $this->router->expects(self::once())
-            ->method('find')
+            ->method('match')
             ->with($request)
             ->willReturn($route);
 
@@ -71,7 +71,7 @@ class RouteHandlerTest extends TestCase
         $callback = uniqid('callback');
         $route    = $this->createRoute($callback);
 
-        $this->router->method('find')->willReturn($route);
+        $this->router->method('match')->willReturn($route);
 
         $object = $this->createMock(InvokableStubInterface::class);
         $object->method('__invoke')->willReturn($response);
@@ -102,7 +102,7 @@ class RouteHandlerTest extends TestCase
         $object   = $this->createMock(InvokableStubInterface::class);
 
         $object->method('__invoke')->willReturn($response);
-        $this->router->method('find')->willReturn($route);
+        $this->router->method('match')->willReturn($route);
         $this->builder->method('build')->willReturn([$object, $method]);
 
         $request->expects(self::exactly(2))
@@ -126,7 +126,7 @@ class RouteHandlerTest extends TestCase
         $route    = $this->createRoute($callback, $params);
         $object   = $this->createMock(InvokableStubInterface::class);
 
-        $this->router->method('find')->willReturn($route);
+        $this->router->method('match')->willReturn($route);
         $this->builder->method('build')->willReturn([$object, $method]);
 
         $object->expects(self::once())
@@ -151,7 +151,7 @@ class RouteHandlerTest extends TestCase
         $object   = $this->createMock(InvokableStubInterface::class);
         $response = $this->createMock(ResponseInterface::class);
 
-        $this->router->method('find')->willReturn($route);
+        $this->router->method('match')->willReturn($route);
         $this->builder->method('build')->willReturn([$object, $method]);
         $object->method('__invoke')->willReturn($response);
 

--- a/tests/RouteMatcherTest.php
+++ b/tests/RouteMatcherTest.php
@@ -187,7 +187,7 @@ class RouteMatcherTest extends TestCase
         $callback,
         array $constraints,
         $name
-    ) {
+    ): Route {
         return new Route($methods, $path, $callback, $constraints, $name);
     }
 
@@ -199,7 +199,7 @@ class RouteMatcherTest extends TestCase
      *
      * @return ServerRequestInterface
      */
-    private function createRequest($method = 'GET', $path = '/')
+    private function createRequest($method = 'GET', $path = '/'): ServerRequestInterface
     {
         $uri = $this->createConfiguredMock(UriInterface::class, ['getPath' => $path]);
 

--- a/tests/RouteMatcherTest.php
+++ b/tests/RouteMatcherTest.php
@@ -107,6 +107,15 @@ class RouteMatcherTest extends TestCase
                 'expectedName' => $nameA,
                 'expectedParams' => [],
             ],
+            'HEAD equals GET' => [
+                'routes' => [
+                    ['GET', $pathA, $callback, [], $nameA],
+                ],
+                'path' => $pathA,
+                'method' => 'HEAD',
+                'expectedName' => $nameA,
+                'expectedParams' => [],
+            ],
             'multiple simple routes, same path' => [
                 'routes' => [
                     ['GET', $pathA, $callback, [], $nameA],

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -401,6 +401,16 @@ class RouteTest extends TestCase
                 'constraints' => [],
                 'expected' => '`^'.$pathA.'\`(?<'.$varA.'>.+?)\`'.$pathB.'$`',
             ],
+            'with constraint, no default' => [
+                'path' => $pathA.'`{'.$varA.'<\d+>}`'.$pathB,
+                'constraints' => [],
+                'expected' => '`^'.$pathA.'\`(?<'.$varA.'>\d+)\`'.$pathB.'$`',
+            ],
+            'with constraint, with default' => [
+                'path' => $pathA.'`{'.$varA.'<\d+>?'.rand().'}`'.$pathB,
+                'constraints' => [],
+                'expected' => '`^'.$pathA.'\`(?<'.$varA.'>\d+)?\`'.$pathB.'$`',
+            ],
         ];
     }
 
@@ -414,5 +424,20 @@ class RouteTest extends TestCase
 
         self::assertEquals('`^'.$prefix.'(?:/(?<'.$key.'>.+?))?$`', $fixture->getPattern());
         self::assertEquals([$key => $default], $fixture->getParams());
+    }
+
+    public function testGetPatternSetsConstraints(): void
+    {
+        $keyA    = uniqid('a');
+        $keyB    = uniqid('a');
+        $value   = uniqid();
+        $default = uniqid();
+        $prefix  = uniqid('/');
+        $regex   = '[A-Za-z0-9]+';
+        $path    = $prefix.'/{'.$keyA.'<'.$regex.'>}';
+        $fixture = new Route([], $path, uniqid(), [$keyB => $value]);
+
+        self::assertEquals('`^'.$prefix.'/(?<'.$keyA.'>'.$regex.')$`', $fixture->getPattern());
+        self::assertEquals([$keyB => $value, $keyA => $regex], $fixture->getConstraints());
     }
 }

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -31,16 +31,17 @@ class RouteTest extends TestCase
         $methodA = uniqid('a');
         $methodB = uniqid('b');
         $fixture = new Route([], uniqid(), uniqid());
-        $fixture->setMethods([$methodA, $methodB]);
 
+        $self   = $fixture->setMethods([$methodA, $methodB]);
         $actual = $fixture->getMethods();
 
+        self::assertSame($fixture, $self);
         self::assertEquals([strtoupper($methodA), strtoupper($methodB)], $actual);
     }
 
     public function testGetPath(): void
     {
-        $path    = uniqid();
+        $path    = uniqid('/');
         $fixture = new Route([], $path, uniqid());
 
         $actual = $fixture->getPath();
@@ -48,15 +49,37 @@ class RouteTest extends TestCase
         self::assertEquals($path, $actual);
     }
 
-    public function testSetPath(): void
+    /**
+     * @param string $path
+     * @param string $expected
+     *
+     * @dataProvider samplePaths
+     */
+    public function testSetPath(string $path, string $expected): void
     {
-        $path    = uniqid();
         $fixture = new Route([], uniqid(), uniqid());
-        $fixture->setPath($path);
 
+        $self   = $fixture->setPath($path);
         $actual = $fixture->getPath();
 
-        self::assertEquals($path, $actual);
+        self::assertSame($fixture, $self);
+        self::assertEquals($expected, $actual);
+    }
+
+    public function samplePaths(): array
+    {
+        $path = uniqid();
+
+        return [
+            'adds slash' => [
+                'path' => $path,
+                'expected' => '/'.$path,
+            ],
+            'removes extra slashs' => [
+                'path' => '/////'.$path,
+                'expected' => '/'.$path,
+            ],
+        ];
     }
 
     public function testGetCallbackWithCallable(): void
@@ -77,10 +100,11 @@ class RouteTest extends TestCase
         };
 
         $fixture = new Route([], uniqid(), uniqid());
-        $fixture->setCallback($callable);
 
+        $self   = $fixture->setCallback($callable);
         $actual = $fixture->getCallback();
 
+        self::assertSame($fixture, $self);
         self::assertSame($callable, $actual);
     }
 
@@ -100,10 +124,11 @@ class RouteTest extends TestCase
         $callable = uniqid();
 
         $fixture = new Route([], uniqid(), uniqid());
-        $fixture->setCallback($callable);
 
+        $self   = $fixture->setCallback($callable);
         $actual = $fixture->getCallback();
 
+        self::assertSame($fixture, $self);
         self::assertSame($callable, $actual);
     }
 
@@ -164,11 +189,70 @@ class RouteTest extends TestCase
         $constraints = [uniqid()];
 
         $fixture = new Route([], uniqid(), uniqid());
-        $fixture->setConstraints($constraints);
+
+        $self   = $fixture->setConstraints($constraints);
+        $actual = $fixture->getConstraints();
+
+        self::assertSame($fixture, $self);
+        self::assertEquals($constraints, $actual);
+    }
+
+    /**
+     * @param mixed[] $existing
+     * @param mixed[] $add
+     * @param mixed[] $expected
+     *
+     * @dataProvider sampleAddData
+     */
+    public function testAddConstraints(array $existing, array $add, array $expected): void
+    {
+        $fixture = new Route([], uniqid(), uniqid(), $existing);
+        $fixture->addConstraints($add);
 
         $actual = $fixture->getConstraints();
 
-        self::assertEquals($constraints, $actual);
+        self::assertEquals($expected, $actual);
+    }
+
+    public function sampleAddData(): array
+    {
+        $keyA   = uniqid('key');
+        $keyB   = uniqid('key');
+        $valueA = uniqid('value');
+        $valueB = uniqid('value');
+
+        return [
+            'no existing, no add' => [
+                'existing' => [],
+                'add' => [],
+                'expected' => [],
+            ],
+            'no existing, one add' => [
+                'existing' => [],
+                'add' => [$keyA => $valueA],
+                'expected' => [$keyA => $valueA],
+            ],
+            'no existing, multiple adds' => [
+                'existing' => [],
+                'add' => [$keyA => $valueA, $keyB => $valueB],
+                'expected' => [$keyA => $valueA, $keyB => $valueB],
+            ],
+            'one existing, one add' => [
+                'existing' => [$keyA => $valueA],
+                'add' => [$keyB => $valueB],
+                'expected' => [$keyA => $valueA, $keyB => $valueB],
+            ],
+            'one existing, one overwrite, one add' => [
+                'existing' => [$keyA => $valueA],
+                'add' => [$keyA => $valueB, $keyB => $valueA],
+                'expected' => [$keyA => $valueB, $keyB => $valueA],
+            ],
+            'multiple existing, no add' => [
+                'existing' => [$keyA => $valueA, $keyB => $valueB],
+                'add' => [],
+                'expected' => [$keyA => $valueA, $keyB => $valueB],
+            ],
+        ];
     }
 
     public function testGetName(): void
@@ -187,10 +271,11 @@ class RouteTest extends TestCase
         $name = uniqid();
 
         $fixture = new Route([], uniqid(), uniqid());
-        $fixture->setName($name);
 
+        $self   = $fixture->setName($name);
         $actual = $fixture->getName();
 
+        self::assertSame($fixture, $self);
         self::assertEquals($name, $actual);
     }
 
@@ -199,11 +284,31 @@ class RouteTest extends TestCase
         $params = [uniqid()];
 
         $fixture = new Route([], uniqid(), uniqid());
-        $fixture->setParams($params);
 
+        $self   = $fixture->setParams($params);
         $actual = $fixture->getParams();
 
+        self::assertSame($fixture, $self);
         self::assertEquals($params, $actual);
+    }
+
+    /**
+     * @param mixed[] $existing
+     * @param mixed[] $add
+     * @param mixed[] $expected
+     *
+     * @dataProvider sampleAddData
+     */
+    public function testAddParams(array $existing, array $add, array $expected): void
+    {
+        $fixture = new Route([], uniqid(), uniqid());
+        $fixture->setParams($existing);
+
+        $self   = $fixture->addParams($add);
+        $actual = $fixture->getParams();
+
+        self::assertSame($fixture, $self);
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -230,8 +335,8 @@ class RouteTest extends TestCase
         $valueA = '\d{'.rand(1, 9).'}';
         $valueB = '\d{'.rand(1, 9).'}';
         $valueC = '\d{'.rand(1, 9).'}';
-        $pathA  = uniqid();
-        $pathB  = uniqid();
+        $pathA  = uniqid('/');
+        $pathB  = uniqid('/');
 
         return [
             'no patterns' => [
@@ -240,9 +345,9 @@ class RouteTest extends TestCase
                 'expected' => '`^'.$pathA.'$`',
             ],
             'one pattern, start' => [
-                'path' => '{'.$varA.'}/'.$pathA,
+                'path' => '/{'.$varA.'}/'.$pathA,
                 'constraints' => [$varA => $valueA],
-                'expected' => '`^(?<'.$varA.'>'.$valueA.')/'.$pathA.'$`',
+                'expected' => '`^/(?<'.$varA.'>'.$valueA.')/'.$pathA.'$`',
             ],
             'one pattern, middle' => [
                 'path' => $pathA.'/{'.$varA.'}/'.$pathB,
@@ -301,7 +406,7 @@ class RouteTest extends TestCase
     {
         $key     = uniqid('a');
         $default = uniqid();
-        $prefix  = uniqid();
+        $prefix  = uniqid('/');
         $path    = $prefix.'/{'.$key.'?'.$default.'}';
         $fixture = new Route([], $path, uniqid());
 

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -322,9 +322,11 @@ class RouteTest extends TestCase
     {
         $fixture = new Route([], $path, uniqid(), $constraints);
 
-        $actual = $fixture->getPattern();
+        $actualA = $fixture->getPattern();
+        $actualB = $fixture->getPattern(); // this should be a cached copy
 
-        self::assertEquals($expected, $actual);
+        self::assertEquals($expected, $actualA);
+        self::assertEquals($expected, $actualB);
     }
 
     public function samplePatterns(): array

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -15,15 +15,6 @@ class RouteTest extends TestCase
         self::assertInstanceOf(RouteInterface::class, $fixture);
     }
 
-    public function testGetIdentifier(): void
-    {
-        $fixture = new Route([], uniqid(), uniqid());
-
-        $actual = $fixture->getIdentifier();
-
-        self::assertEquals('route_0', $actual);
-    }
-
     public function testGetMethods(): void
     {
         $methodA = uniqid('a');

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -346,7 +346,12 @@ class RouteTest extends TestCase
                 'constraints' => [],
                 'expected' => [
                     'regex' => '`^'.$pathA.'$`',
-                    'tokens' => [],
+                    'tokens' => [
+                        [
+                            'type' => 'text',
+                            'prefix' => $pathA,
+                        ],
+                    ],
                 ],
             ],
             'one pattern, start' => [
@@ -356,10 +361,19 @@ class RouteTest extends TestCase
                     'regex' => '`^/(?<'.$varA.'>'.$valueA.')/'.$pathA.'$`',
                     'tokens' => [
                         [
+                            'type' => 'text',
+                            'prefix' => '/',
+                        ],
+                        [
+                            'type' => 'param',
                             'name' => $varA,
                             'optional' => false,
                             'regex' => '(?<'.$varA.'>'.$valueA.')',
-                            'prefix' => '/',
+                            'prefix' => '',
+                        ],
+                        [
+                            'type' => 'text',
+                            'prefix' => '/'.$pathA,
                         ],
                     ],
                 ],
@@ -371,10 +385,19 @@ class RouteTest extends TestCase
                     'regex' => '`^'.$pathA.'/(?<'.$varA.'>'.$valueA.')/'.$pathB.'$`',
                     'tokens' => [
                         [
+                            'type' => 'text',
+                            'prefix' => $pathA.'/',
+                        ],
+                        [
+                            'type' => 'param',
                             'name' => $varA,
                             'optional' => false,
                             'regex' => '(?<'.$varA.'>'.$valueA.')',
-                            'prefix' => $pathA.'/',
+                            'prefix' => '',
+                        ],
+                        [
+                            'type' => 'text',
+                            'prefix' => '/'.$pathB,
                         ],
                     ],
                 ],
@@ -386,10 +409,15 @@ class RouteTest extends TestCase
                     'regex' => '`^'.$pathA.'/(?<'.$varA.'>'.$valueA.')$`',
                     'tokens' => [
                         [
+                            'type' => 'text',
+                            'prefix' => $pathA.'/',
+                        ],
+                        [
+                            'type' => 'param',
                             'name' => $varA,
                             'optional' => false,
                             'regex' => '(?<'.$varA.'>'.$valueA.')',
-                            'prefix' => $pathA.'/',
+                            'prefix' => '',
                         ],
                     ],
                 ],
@@ -401,10 +429,15 @@ class RouteTest extends TestCase
                     'regex' => '`^'.$pathA.'(?<'.$varA.'>.+?)$`',
                     'tokens' => [
                         [
+                            'type' => 'text',
+                            'prefix' => $pathA,
+                        ],
+                        [
+                            'type' => 'param',
                             'name' => $varA,
                             'optional' => false,
                             'regex' => '(?<'.$varA.'>.+?)',
-                            'prefix' => $pathA,
+                            'prefix' => '',
                         ],
                     ],
                 ],
@@ -420,22 +453,33 @@ class RouteTest extends TestCase
                         .'/(?<'.$varC.'>.+?)$`',
                     'tokens' => [
                         [
-                            'name' => $varA,
-                            'optional' => false,
-                            'regex' => '(?<'.$varA.'>'.$valueA.')',
+                            'type' => 'text',
                             'prefix' => $pathA.'/',
                         ],
                         [
+                            'type' => 'param',
+                            'name' => $varA,
+                            'optional' => false,
+                            'regex' => '(?<'.$varA.'>'.$valueA.')',
+                            'prefix' => '',
+                        ],
+                        [
+                            'type' => 'param',
                             'name' => $varB,
                             'optional' => false,
                             'regex' => '(?<'.$varB.'>'.$valueB.')',
                             'prefix' => '',
                         ],
                         [
+                            'type' => 'text',
+                            'prefix' => '/',
+                        ],
+                        [
+                            'type' => 'param',
                             'name' => $varC,
                             'optional' => false,
                             'regex' => '(?<'.$varC.'>.+?)',
-                            'prefix' => '/',
+                            'prefix' => '',
                         ],
                     ],
                 ],
@@ -447,10 +491,19 @@ class RouteTest extends TestCase
                     'regex' => '`^'.$pathA.'(?<'.$varA.'>'.$valueA.')?'.$pathB.'$`',
                     'tokens' => [
                         [
+                            'type' => 'text',
+                            'prefix' => $pathA,
+                        ],
+                        [
+                            'type' => 'param',
                             'name' => $varA,
                             'optional' => true,
                             'regex' => '(?<'.$varA.'>'.$valueA.')',
-                            'prefix' => $pathA,
+                            'prefix' => '',
+                        ],
+                        [
+                            'type' => 'text',
+                            'prefix' => $pathB,
                         ],
                     ],
                 ],
@@ -462,10 +515,15 @@ class RouteTest extends TestCase
                     'regex' => '`^(?:/(?<'.$varA.'>'.$valueA.'))?/'.$pathB.'$`',
                     'tokens' => [
                         [
+                            'type' => 'param',
                             'name' => $varA,
                             'optional' => true,
                             'regex' => '(?:/(?<'.$varA.'>'.$valueA.'))',
-                            'prefix' => '',
+                            'prefix' => '/',
+                        ],
+                        [
+                            'type' => 'text',
+                            'prefix' => '/'.$pathB,
                         ],
                     ],
                 ],
@@ -477,10 +535,15 @@ class RouteTest extends TestCase
                     'regex' => '`^'.$pathA.'(?:\.(?<'.$varA.'>'.$valueA.'))?$`',
                     'tokens' => [
                         [
+                            'type' => 'text',
+                            'prefix' => $pathA,
+                        ],
+                        [
+                            'type' => 'param',
                             'name' => $varA,
                             'optional' => true,
                             'regex' => '(?:\.(?<'.$varA.'>'.$valueA.'))',
-                            'prefix' => $pathA,
+                            'prefix' => '.',
                         ],
                     ],
                 ],
@@ -493,22 +556,29 @@ class RouteTest extends TestCase
                         .'(?:/(?<'.$varB.'>.+?))?(?:/(?<'.$varC.'>.+?))?/'.$pathB.'$`',
                     'tokens' => [
                         [
+                            'type' => 'param',
                             'name' => $varA,
                             'optional' => true,
                             'regex' => '(?:/(?<'.$varA.'>'.$valueA.'))',
-                            'prefix' => '',
+                            'prefix' => '/',
                         ],
                         [
+                            'type' => 'param',
                             'name' => $varB,
                             'optional' => true,
                             'regex' => '(?:/(?<'.$varB.'>.+?))',
-                            'prefix' => '',
+                            'prefix' => '/',
                         ],
                         [
+                            'type' => 'param',
                             'name' => $varC,
                             'optional' => true,
                             'regex' => '(?:/(?<'.$varC.'>.+?))',
-                            'prefix' => '',
+                            'prefix' => '/',
+                        ],
+                        [
+                            'type' => 'text',
+                            'prefix' => '/'.$pathB,
                         ],
                     ],
                 ],
@@ -520,10 +590,19 @@ class RouteTest extends TestCase
                     'regex' => '`^'.$pathA.'\`(?<'.$varA.'>.+?)\`'.$pathB.'$`',
                     'tokens' => [
                         [
+                            'type' => 'text',
+                            'prefix' => $pathA.'`',
+                        ],
+                        [
+                            'type' => 'param',
                             'name' => $varA,
                             'optional' => false,
                             'regex' => '(?<'.$varA.'>.+?)',
-                            'prefix' => $pathA.'\`',
+                            'prefix' => '',
+                        ],
+                        [
+                            'type' => 'text',
+                            'prefix' => '`'.$pathB,
                         ],
                     ],
                 ],
@@ -535,10 +614,19 @@ class RouteTest extends TestCase
                     'regex' => '`^'.$pathA.'\`(?<'.$varA.'>\d+)\`'.$pathB.'$`',
                     'tokens' => [
                         [
+                            'type' => 'text',
+                            'prefix' => $pathA.'`',
+                        ],
+                        [
+                            'type' => 'param',
                             'name' => $varA,
                             'optional' => false,
                             'regex' => '(?<'.$varA.'>\d+)',
-                            'prefix' => $pathA.'\`',
+                            'prefix' => '',
+                        ],
+                        [
+                            'type' => 'text',
+                            'prefix' => '`'.$pathB,
                         ],
                     ],
                 ],
@@ -550,10 +638,19 @@ class RouteTest extends TestCase
                     'regex' => '`^'.$pathA.'\`(?<'.$varA.'>\d+)?\`'.$pathB.'$`',
                     'tokens' => [
                         [
+                            'type' => 'text',
+                            'prefix' => $pathA.'`',
+                        ],
+                        [
+                            'type' => 'param',
                             'name' => $varA,
                             'optional' => true,
                             'regex' => '(?<'.$varA.'>\d+)',
-                            'prefix' => $pathA.'\`',
+                            'prefix' => '',
+                        ],
+                        [
+                            'type' => 'text',
+                            'prefix' => '`'.$pathB,
                         ],
                     ],
                 ],

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -54,16 +54,24 @@ class RouterTest extends TestCase
     {
         $methods     = [uniqid('method'), uniqid('method')];
         $path        = uniqid('path');
-        $callable    = function () {
-        };
+        $callable    = uniqid();
         $constraints = [uniqid('key') => uniqid('value')];
         $name        = uniqid('name');
 
-        $this->routes->expects(self::once())
+        $spy = self::once();
+        $this->routes->expects($spy)
             ->method('add')
-            ->with($methods, $path, $callable, $constraints, $name);
+            ->with(self::isInstanceOf(RouteInterface::class));
 
-        $this->fixture->add($methods, $path, $callable, $constraints, $name);
+        $actual = $this->fixture->add($methods, $path, $callable, $constraints, $name);
+
+        $route = $spy->getInvocations()[0]->getParameters()[0];
+        self::assertSame($route, $actual);
+        self::assertEquals(array_map('strtoupper', $methods), $actual->getMethods());
+        self::assertEquals($path, $actual->getPath());
+        self::assertEquals($callable, $actual->getCallback());
+        self::assertEquals($constraints, $actual->getConstraints());
+        self::assertEquals($name, $actual->getName());
     }
 
     public function testHas(): void

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -53,7 +53,7 @@ class RouterTest extends TestCase
     public function testAdd(): void
     {
         $methods     = [uniqid('method'), uniqid('method')];
-        $path        = uniqid('path');
+        $path        = uniqid('/path');
         $callable    = uniqid();
         $constraints = [uniqid('key') => uniqid('value')];
         $name        = uniqid('name');

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -104,7 +104,7 @@ class RouterTest extends TestCase
         self::assertSame($route, $actual);
     }
 
-    public function testFind(): void
+    public function testMatch(): void
     {
         $route   = $this->createMock(RouteInterface::class);
         $request = $this->createMock(ServerRequestInterface::class);
@@ -114,7 +114,7 @@ class RouterTest extends TestCase
             ->with($request)
             ->willReturn($route);
 
-        $actual = $this->fixture->find($request);
+        $actual = $this->fixture->match($request);
 
         self::assertSame($route, $actual);
     }

--- a/tests/UriGeneratorTest.php
+++ b/tests/UriGeneratorTest.php
@@ -83,7 +83,7 @@ class UriGeneratorTest extends TestCase
         $pathB  = uniqid('path');
         $paramA = rand(); // non-string
         $paramB = uniqid('param');
-        $domain = uniqid('domain');
+        $domain = uniqid('scheme://');
 
         return [
             'no params' => [
@@ -140,7 +140,7 @@ class UriGeneratorTest extends TestCase
                 'name' => $name,
                 'params' => [],
                 'type' => UriGeneratorInterface::ABSOLUTE_URI,
-                'expected' => '/'.$domain.'/'.$pathB,
+                'expected' => $domain.'/'.$pathB,
             ],
             'path with leading slash' => [
                 'path' => $pathA,
@@ -148,7 +148,7 @@ class UriGeneratorTest extends TestCase
                 'name' => $name,
                 'params' => [],
                 'type' => UriGeneratorInterface::ABSOLUTE_URI,
-                'expected' => '/'.$domain.$pathA,
+                'expected' => $domain.$pathA,
             ],
             'no slashes' => [
                 'path' => $pathB,
@@ -156,7 +156,15 @@ class UriGeneratorTest extends TestCase
                 'name' => $name,
                 'params' => [],
                 'type' => UriGeneratorInterface::ABSOLUTE_URI,
-                'expected' => '/'.$domain.'/'.$pathB,
+                'expected' => $domain.'/'.$pathB,
+            ],
+            'network uri' => [
+                'path' => $pathA,
+                'domain' => 'scheme://'.$name,
+                'name' => $name,
+                'params' => [],
+                'type' => UriGeneratorInterface::NETWORK_URI,
+                'expected' => '//'.$name.$pathA,
             ],
             'trailing text' => [
                 'path' => $pathA.'/{paramA}/'.$pathB,

--- a/tests/UriGeneratorTest.php
+++ b/tests/UriGeneratorTest.php
@@ -3,8 +3,8 @@
 namespace Bitty\Tests\Router;
 
 use Bitty\Router\Exception\UriGeneratorException;
+use Bitty\Router\Route;
 use Bitty\Router\RouteCollectionInterface;
-use Bitty\Router\RouteInterface;
 use Bitty\Router\UriGenerator;
 use Bitty\Router\UriGeneratorInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -39,7 +39,7 @@ class UriGeneratorTest extends TestCase
     public function testGenerateGetsRoute(): void
     {
         $name  = uniqid();
-        $route = $this->createConfiguredMock(RouteInterface::class, ['getPath' => '']);
+        $route = new Route([], uniqid(), uniqid());
 
         $this->routes->expects(self::once())
             ->method('get')
@@ -67,7 +67,7 @@ class UriGeneratorTest extends TestCase
         string $type,
         string $expected
     ): void {
-        $route = $this->createConfiguredMock(RouteInterface::class, ['getPath' => $path]);
+        $route = new Route([], $path, uniqid());
         $this->routes->method('get')->willReturn($route);
 
         $fixture = new UriGenerator($this->routes, $domain);
@@ -158,13 +158,61 @@ class UriGeneratorTest extends TestCase
                 'type' => UriGeneratorInterface::ABSOLUTE_URI,
                 'expected' => '/'.$domain.'/'.$pathB,
             ],
+            'trailing text' => [
+                'path' => $pathA.'/{paramA}/'.$pathB,
+                'domain' => '',
+                'name' => $name,
+                'params' => ['paramA' => $paramA],
+                'type' => UriGeneratorInterface::ABSOLUTE_PATH,
+                'expected' => $pathA.'/'.$paramA.'/'.$pathB,
+            ],
+            'optional param' => [
+                'path' => $pathA.'/{paramA?}',
+                'domain' => '',
+                'name' => $name,
+                'params' => ['paramB' => $paramB],
+                'type' => UriGeneratorInterface::ABSOLUTE_PATH,
+                'expected' => $pathA.'?paramB='.$paramB,
+            ],
+            'optional param in the middle' => [
+                'path' => $pathA.'/{paramA?}/'.$pathB,
+                'domain' => '',
+                'name' => $name,
+                'params' => ['paramB' => $paramB],
+                'type' => UriGeneratorInterface::ABSOLUTE_PATH,
+                'expected' => $pathA.'/'.$pathB.'?paramB='.$paramB,
+            ],
+            'multiple optional params, no values' => [
+                'path' => $pathA.'/{paramA?}/{paramB?}',
+                'domain' => '',
+                'name' => $name,
+                'params' => [],
+                'type' => UriGeneratorInterface::ABSOLUTE_PATH,
+                'expected' => $pathA,
+            ],
+            'multiple optional params, one value' => [
+                'path' => $pathA.'/{paramA?}/{paramB?}',
+                'domain' => '',
+                'name' => $name,
+                'params' => ['paramA' => $paramA],
+                'type' => UriGeneratorInterface::ABSOLUTE_PATH,
+                'expected' => $pathA.'/'.$paramA,
+            ],
+            'optional param with default value' => [
+                'path' => $pathA.'/{paramA?'.rand().'}',
+                'domain' => '',
+                'name' => $name,
+                'params' => ['paramB' => $paramB],
+                'type' => UriGeneratorInterface::ABSOLUTE_PATH,
+                'expected' => $pathA.'?paramB='.$paramB,
+            ],
         ];
     }
 
     public function testGenerateThrowsException(): void
     {
         $path  = uniqid('path').'/{param}';
-        $route = $this->createConfiguredMock(RouteInterface::class, ['getPath' => $path]);
+        $route = new Route([], $path, uniqid());
         $this->routes->method('get')->willReturn($route);
 
         $this->expectException(UriGeneratorException::class);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,0 @@
-<?php
-
-require dirname(__DIR__).'/vendor/autoload.php';
-
-error_reporting(E_ALL);


### PR DESCRIPTION
# BC Breaks:
- Changed `RouteCollection::add()` to take a `RouteInterface` (d4ade1dd282fb6a453168219ad2981c7fbc1ade4).
- Expanded `RouteCollection` to support route groups (9fa5b0e5792518f7fb21d391bfde1d6ea9d23989).
- Renamed `Router::find()` to `Router::match()` (e8f8a2780f673a17a227377c01375fa89b629e3a).
- Expanded `RouteInterface` and made it fluent.
- Dropped `RouteInterface::getPattern`. Replaced it with `compile()`.

# Added:
- Optional constraints in route path (3381c3471051eef3ad049c9d78508398da63de82).
- Support for generating network URIs (5fa6929b0a6a17109d9f12aaf07c8149fdff0d68).
- Added support to `RouteMatcher` so HEAD is seen as GET (58a4e1beb4f16e004e268ea9b6b106a9ce620784).
